### PR TITLE
HID-2027: new keys for each AWS environment

### DIFF
--- a/api/services/JwtService.js
+++ b/api/services/JwtService.js
@@ -11,7 +11,7 @@ module.exports = {
   // Generates a token from supplied payload
   issue(payload) {
     const cert = fs.readFileSync('keys/sign.rsa');
-    const options = { algorithm: 'RS256', header: { kid: 'hid-v3' } };
+    const options = { algorithm: 'RS256', header: { kid: `hid-v3-${process.env.NODE_ENV}` } };
     return jwt.sign(
       payload,
       cert,


### PR DESCRIPTION
# HID-2027

We are doing a two-stage verification of the tokens to allow a smoother transition to both AWS and HIDv3.

@teodorescuserban this will NOT function without your half of the job. There MUST be a new RSA keypair at the following locations managed by Ansible vault:

- `keys/sign.rsa`
- `keys/sign.rsa.pub` 

I tested this locally using two locally-generated keys and it seems to do the job. My workflow was as follows:

1. Generate a 256-bit RSA keypair called `hid.rsa` (plus public half)
2. Generate a 256-bit RSA keypair called `sign.rsa` (plus public half)
3. I signed into HID with original `JwtService.issue()` un-altered using `hid.rsa`
4. Logging out and logging back in was possible. My user is able to do everything it has permissions to do (e.g. edit profile or see lists). **This is the use-case of HID-2027: an existing user on dev/prod who logged in when OLD key was present should still be able to use the site.**
5. Logged out.
6. I changed `JwtService.issue()` to use the new `sign.rsa`
7. Logged in again while API is using new, key, refreshing and doing other actions is still possible.
