### PR TITLE
HID-2281: remove IASC special-case

### DIFF
--- a/api/models/OauthToken.js
+++ b/api/models/OauthToken.js
@@ -1,13 +1,13 @@
-const mongoose = require('mongoose');
-const crypto = require('crypto');
-
-const { Schema } = mongoose;
-
 /**
  * @module OauthToken
  * @description Oauth Token
  */
+const mongoose = require('mongoose');
+const crypto = require('crypto');
+const config = require('../../config/env');
 
+const { logger } = config;
+const { Schema } = mongoose;
 const OauthTokenSchema = new Schema({
   type: {
     type: String,
@@ -64,6 +64,22 @@ OauthTokenSchema.statics = {
       nonce,
       expires: now + 7 * 24 * 3600 * 1000,
     };
+
+    logger.info(
+      `[OauthToken->generate] generating ${type} OAuth token`,
+      {
+        oauth: {
+          type,
+          client_id: client._id,
+        },
+        user: {
+          id: user._id,
+          email: user.email,
+          admin: user.is_admin,
+        },
+      },
+    );
+
     return ftoken;
   },
 };

--- a/api/services/JwtService.js
+++ b/api/services/JwtService.js
@@ -1,17 +1,41 @@
-const jwt = require('jsonwebtoken');
-const fs = require('fs');
-const rsa2jwk = require('rsa-pem-to-jwk');
-
 /**
  * @module JwtService
  * @description JSON Web Token Service
  */
+
+const jwt = require('jsonwebtoken');
+const fs = require('fs');
+const rsa2jwk = require('rsa-pem-to-jwk');
+const config = require('../../config/env');
+
+const { logger } = config;
+
 module.exports = {
 
   // Generates a token from supplied payload
   issue(payload) {
     const cert = fs.readFileSync('keys/hid.rsa');
     const options = { algorithm: 'RS256', header: { kid: 'hid-dev' } };
+    const loggedUser = {};
+
+    if (payload.id) {
+      loggedUser.id = payload.id;
+    }
+    if (payload.sub) {
+      loggedUser.id = payload.sub;
+    }
+
+    logger.info(
+      '[JwtService->issue] issuing JWT',
+      {
+        security: true,
+        user: loggedUser,
+        oauth: {
+          client_id: payload.client || '',
+        },
+      },
+    );
+
     return jwt.sign(
       payload,
       cert,
@@ -44,16 +68,37 @@ module.exports = {
       iat: now,
       auth_time: Math.floor(user.auth_time.getTime() / 1000),
     };
+
     if (scope.indexOf('email') !== -1) {
+      loggedScopes.push('email');
       idToken.email = user.email;
       idToken.email_verified = user.email_verified;
     }
+
     if (scope.indexOf('profile') !== -1) {
+      loggedScopes.push('profile');
       idToken.name = user.name;
       idToken.family_name = user.family_name;
       idToken.given_name = user.given_name;
       idToken.updated_at = user.updatedAt;
     }
+
+    logger.info(
+      '[JwtService->generateIdToken] Generating ID token',
+      {
+        security: true,
+        oauth: {
+          client_id: client.id,
+          scopes: loggedScopes.join(','),
+        },
+        user: {
+          id: user.id,
+          email: user.email,
+          admin: user.is_admin,
+        },
+      },
+    );
+
     return this.issue(idToken);
   },
 

--- a/api/services/JwtService.js
+++ b/api/services/JwtService.js
@@ -32,10 +32,9 @@ module.exports = {
 
   generateIdToken(client, user, scope, nonce) {
     const now = Math.floor(Date.now() / 1000);
-    let sub = user._id;
-    if (client.id === 'iasc-prod' || client.id === 'iasc-dev') {
-      sub = user.email;
-    }
+    const sub = user.id;
+    const loggedScopes = [];
+
     const idToken = {
       iss: process.env.ROOT_URL,
       sub,

--- a/config/web.js
+++ b/config/web.js
@@ -207,15 +207,15 @@ module.exports = {
     const OauthExpiresIn = 24 * 3600;
 
     // Register supported OpenID Connect 1.0 grant types.
-
     oauth.grant(oauth2orizeExt.extensions());
-    // id_token grant type.
+
+    // Grant type: 'id_token'
     oauth.grant(oauth2orizeExt.grant.idToken((client, user, req, done) => {
       const out = JwtService.generateIdToken(client, user, req.scope, req.nonce);
       done(null, out);
     }));
 
-    // 'id_token token' grant type.
+    // Grant type: 'id_token token'
     oauth.grant(oauth2orizeExt.grant.idTokenToken(
       async (client, user, done) => {
         try {
@@ -242,6 +242,7 @@ module.exports = {
         return done(err);
       }
     }));
+
     // Authorization code exchange flow
     oauth.grant(oauth.grants.code(async (client, redirectURI, user, res, req, done) => {
       const nonce = req.nonce ? req.nonce : '';
@@ -253,6 +254,7 @@ module.exports = {
         return done(err);
       }
     }));
+
 
     oauth.exchange(oauth.exchanges.code(
       async (client, code, redirectURI, payload, authInfo, done) => {

--- a/plugins/hapi-auth-hid/index.js
+++ b/plugins/hapi-auth-hid/index.js
@@ -44,6 +44,8 @@ internals.tokenToUser = async (token) => {
           security: true,
           user: {
             id: jtoken.id,
+            email: user.email,
+            admin: user.is_admin,
           },
         },
       );

--- a/plugins/hapi-auth-hid/index.js
+++ b/plugins/hapi-auth-hid/index.js
@@ -74,6 +74,7 @@ internals.tokenToUser = async (token) => {
       );
       throw Boom.unauthorized('Invalid Token!');
     }
+
     if (tok.isExpired()) {
       logger.warn(
         'Token is expired',
@@ -84,6 +85,7 @@ internals.tokenToUser = async (token) => {
       );
       throw Boom.unauthorized('Expired token');
     }
+
     logger.info(
       'Successful authentication through OAuth token',
       {


### PR DESCRIPTION
# HID-2281

The PR itself could have been tiny, but in the process of debugging and testing I realized there's a whole set of operations relating to this process that don't log any activity. So I added some logs too.

## Testing

1. Log into a local Drupal website of your choice using local HID. The login must succeed so that you can see your username inside the Drupal website.

If you get GuzzleHttp errors, you probably need to add an entry to `/etc/hosts` to point `hid.test` to the container's "external network" IP. I normally find that by running: `/sbin/ip route|awk '/default/ { print $3 }'`

2. Log into HID as an admin, and edit the `iasc-dev` client to note all the credentials, plus add a redirect URL of your choice that points to the local Drupal setup from (1).
3. With the credentials you found in (2), reconfigure any local Drupal to use the IASC credentials.
4. Log into local Drupal with local HID **with the same HID user as you used during step (1)**.

If you are able to log in with the same user in (1) and (4) it seems like a good indication that dropping this code won't disrupt anything.

The additional logging will hopefully illuminate the process as you log in the two times.