### PR TITLE
HID-2257: upgrade mongoose to 6.x

### DIFF
--- a/api/controllers/AuthController.js
+++ b/api/controllers/AuthController.js
@@ -282,7 +282,7 @@ module.exports = {
         const offset = 5 * 60 * 1000;
         const d5minutes = new Date(now - offset);
         const [floodCount, user] = await Promise.all([
-          Flood.count({
+          Flood.countDocuments({
             type: 'totp',
             email: cookie.userId,
             createdAt: {

--- a/api/controllers/ClientController.js
+++ b/api/controllers/ClientController.js
@@ -315,7 +315,7 @@ module.exports = {
 
     // If a client was found, delete it and log the event.
     if (client) {
-      await client.remove();
+      await client.deleteOne();
 
       logger.info(
         '[ClientController->destroy] Removed client',

--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -411,16 +411,27 @@ module.exports = {
         {
           request,
           security: true,
+          user: {
+            id: user.id,
+            email: user.email,
+            admin: user.is_admin,
+          },
         },
       );
       return reply.response().code(204);
     }
+
     logger.warn(
       `[TOTPController->destroyDevice] Could not find device ${deviceId} for ${request.auth.credentials.id}`,
       {
         request,
         security: true,
         fail: true,
+        user: {
+          id: user.id,
+          email: user.email,
+          admin: user.is_admin,
+        },
       },
     );
     throw Boom.notFound();

--- a/api/controllers/TOTPController.js
+++ b/api/controllers/TOTPController.js
@@ -403,6 +403,7 @@ module.exports = {
     const user = request.auth.credentials;
     const deviceId = request.params.id;
     const device = user.totpTrusted.id(deviceId);
+
     if (device) {
       user.totpTrusted.id(deviceId).remove();
       await user.save();

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -497,7 +497,7 @@ module.exports = {
     await EmailService.sendAdminDelete(user, request.auth.credentials);
 
     // Delete this user.
-    await user.remove();
+    await user.deleteOne();
 
     logger.info(
       `[UserController->destroy] Removed user ${request.params.id}`,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -497,7 +497,16 @@ module.exports = {
     await EmailService.sendAdminDelete(user, request.auth.credentials);
 
     // Delete this user.
-    await user.deleteOne();
+    await user.deleteOne().catch((err) => {
+      logger.error(
+        `[UserController->destroy] ${err.message}`,
+        {
+          request,
+          fail: true,
+          stack_trace: err.stack,
+        },
+      );
+    });
 
     logger.info(
       `[UserController->destroy] Removed user ${request.params.id}`,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1663,7 +1663,16 @@ module.exports = {
         alert.message = `<p>${reasons.join('</p><p>')}</p>`;
       } else {
         // So long, and thanks for all the fish!
-        await user.deleteOne();
+        await user.deleteOne().catch((err) => {
+          logger.error(
+            `[ViewController->settingsDeleteSubmit] ${err.message}`,
+            {
+              request,
+              fail: true,
+              stack_trace: err.stack,
+            },
+          );
+        });
 
         logger.info(
           `[ViewController->settingsDeleteSubmit] Removed user ${cookie.userId}`,

--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -1663,7 +1663,7 @@ module.exports = {
         alert.message = `<p>${reasons.join('</p><p>')}</p>`;
       } else {
         // So long, and thanks for all the fish!
-        await user.remove();
+        await user.deleteOne();
 
         logger.info(
           `[ViewController->settingsDeleteSubmit] Removed user ${cookie.userId}`,

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -16,7 +16,10 @@ const config = require('../../config/env');
 const { logger } = config;
 const { Schema } = mongoose;
 const populateClients = [
-  { path: 'authorizedClients', select: '_id id name organization environment redirectUri redirectUrls' },
+  {
+    path: 'authorizedClients',
+    select: '_id id name organization environment redirectUri redirectUrls',
+  },
 ];
 
 function isHTMLValidator(v) {
@@ -381,7 +384,7 @@ UserSchema.post('findOne', async function (result, next) {
   }
   try {
     if (typeof result.populate === 'function') {
-      await result.populate(populateClients).execPopulate();
+      await result.populate(populateClients);
     }
     return next();
   } catch (err) {
@@ -765,8 +768,8 @@ UserSchema.methods = {
     return false;
   },
 
-  defaultPopulate() {
-    return this.populate(populateClients).execPopulate();
+  async defaultPopulate() {
+    return await this.populate(populateClients);
   },
 
   trustedDeviceIndex(ua) {

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -769,7 +769,7 @@ UserSchema.methods = {
   },
 
   async defaultPopulate() {
-    return await this.populate(populateClients);
+    return this.populate(populateClients);
   },
 
   trustedDeviceIndex(ua) {

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -80,6 +80,8 @@ async function isTOTPValid(user, token) {
 }
 
 module.exports = {
+  isTOTPValid,
+
   /**
    * Enforces an _optional_ TOTP requirement. If the user has 2FA enabled, they
    * must answer this challenge. Users without 2FA enabled will pass through.

--- a/config/env/index.js
+++ b/config/env/index.js
@@ -50,12 +50,10 @@ const config = {
       migrate: 'create',
       uri: databaseUri,
       options: {
-        keepAlive: 600000,
+        keepAlive: 'true',
         connectTimeoutMS: 60000,
         useNewUrlParser: true,
         useUnifiedTopology: true,
-        useFindAndModify: false,
-        useCreateIndex: true,
       },
     },
     models: {

--- a/config/web.js
+++ b/config/web.js
@@ -268,7 +268,7 @@ module.exports = {
           const accessToken = OauthToken.generate('access', client, ocode.user, ocode.nonce);
           promises.push(OauthToken.create(refreshToken));
           promises.push(OauthToken.create(accessToken));
-          promises.push(OauthToken.remove({ type: 'code', token: code }));
+          promises.push(OauthToken.deleteOne({ type: 'code', token: code }));
           const tokens = await Promise.all(promises);
           const scope = ['openid'];
           return done(null, tokens[1].token, tokens[0].token, {

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 5.0.1
+  version: 5.1.0
   title: HID API
   license:
     name: Apache-2.0
@@ -11,7 +11,7 @@ servers:
     description: Staging server. For use by all UNOCHA developers.
   - url: 'https://api.humanitarian.id/api/v3'
     description: Production server. For use by HID Authentication Partners.
-  - url: 'http://hid.test/api/v3'
+  - url: 'http://hid.test:8080/api/v3'
     description: Localhost server. For local dev/debugging.
 
 tags:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3327,14 +3327,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/bson": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
-      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -3384,15 +3376,6 @@
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
       "dev": true
     },
-    "@types/mongodb": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.9.tgz",
-      "integrity": "sha512-2XSGr/+IOKeFQ5tU9ATcIiIr7bpHqWyOXNGLOOhp0kg2NnfEvoKZF1SZ25j4zvJRqM2WeSUjfWSvymFJ3HBGJQ==",
-      "requires": {
-        "@types/bson": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/node": {
       "version": "14.14.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.34.tgz",
@@ -3415,6 +3398,20 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -4017,58 +4014,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "bl": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
-      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
-      "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          },
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.1.2",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-            }
-          }
-        }
-      }
-    },
     "blankie": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/blankie/-/blankie-5.0.0.tgz",
@@ -4341,9 +4286,12 @@
       }
     },
     "bson": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.0.tgz",
+      "integrity": "sha512-8jw1NU1hglS+Da1jDOUYuNcBJ4cNHCFIqzlwoFNnsTOg2R/ox0aTYcTiBN4dzRa9q7Cvy6XErh3L8ReTEb9AQQ==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
     },
     "buffer": {
       "version": "5.7.1",
@@ -5459,11 +5407,18 @@
       "integrity": "sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig=="
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decamelize": {
@@ -10797,34 +10752,69 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.4.tgz",
-      "integrity": "sha512-Y+Ki9iXE9jI+n9bVtbTOOdK0B95d6wVGSucwtBkvQ+HIvVdTCfpVRp01FDC24uhC/Q2WXQ8Lpq3/zwtB5Op9Qw==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.1.4.tgz",
+      "integrity": "sha512-Cv/sk8on/tpvvqbEvR1h03mdyNdyvvO+WhtFlL4jrZ+DSsN/oSQHVqmJQI/sBCqqbOArFcYCAYDfyzqFwV4GSQ==",
       "requires": {
-        "bl": "^2.2.1",
-        "bson": "^1.1.4",
-        "denque": "^1.4.1",
-        "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "bson": "^4.5.4",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.1.0",
+        "saslprep": "^1.0.3"
+      },
+      "dependencies": {
+        "denque": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+          "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+        }
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.2.0.tgz",
+      "integrity": "sha512-U0cDxLUrQrl7DZA828CA+o69EuWPWEJTwdMPozyd7cy/dbtncUZczMw7wRHcwMD7oKOn0NM2tF9jdf5FFVW9CA==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "mongoose": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.12.0.tgz",
-      "integrity": "sha512-s0Qpgf5lOk3AXtKnE+FA0HZhFKa2hesGVcTmx1wfTQ+7Q7ph0E79B6KUp1ZQERQyCwuE8WQ4wWllEhd7VPkxOg==",
+      "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.0.14.tgz",
+      "integrity": "sha512-SZ0kBlHrz/G70yWdVXLfM/gH4NsY85+as4MZRdtWxBTDEcmoE3rCFAz1/Ho2ycg5mJAeOBwdGZw4a5sn/WrwUA==",
       "requires": {
-        "@types/mongodb": "^3.5.27",
-        "bson": "^1.1.4",
+        "bson": "^4.2.2",
         "kareem": "2.3.2",
-        "mongodb": "3.6.4",
-        "mongoose-legacy-pluralize": "1.0.2",
-        "mpath": "0.8.3",
-        "mquery": "3.2.4",
+        "mongodb": "4.1.4",
+        "mpath": "0.8.4",
+        "mquery": "4.0.0",
         "ms": "2.1.2",
         "regexp-clone": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "sift": "7.0.1",
+        "sift": "13.5.2",
         "sliced": "1.0.1"
       },
       "dependencies": {
@@ -10832,18 +10822,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
-    },
-    "mongoose-legacy-pluralize": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mongoose-validator": {
       "version": "1.3.2",
@@ -10867,32 +10847,18 @@
       "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w=="
     },
     "mpath": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
-      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "mquery": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.4.tgz",
-      "integrity": "sha512-uOLpp7iRX0BV1Uu6YpsqJ5b42LwYnmu0WeF/f8qgD/On3g0XDaQM6pfn0m6UxO6SM8DioZ9Bk6xxbWIGHm2zHg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.0.tgz",
+      "integrity": "sha512-nGjm89lHja+T/b8cybAby6H0YgA4qYC/lx6UlwvHGqvTq8bDaNeCwl1sY8uRELrNbVWJzIihxVd+vphGGn1vBw==",
       "requires": {
-        "bluebird": "3.5.1",
-        "debug": "3.1.0",
+        "debug": "4.x",
         "regexp-clone": "^1.0.0",
-        "safe-buffer": "5.1.2",
         "sliced": "1.0.1"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.1",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "ms": {
@@ -12270,15 +12236,6 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
     },
-    "require_optional": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-      "requires": {
-        "resolve-from": "^2.0.0",
-        "semver": "^5.1.0"
-      }
-    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -12314,11 +12271,6 @@
         "expand-tilde": "^1.2.2",
         "global-modules": "^0.2.3"
       }
-    },
-    "resolve-from": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "resolve.exports": {
       "version": "1.1.0",
@@ -12418,7 +12370,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -12504,9 +12457,9 @@
       }
     },
     "sift": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
-      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.21",
     "moment": "^2.24.0",
-    "mongoose": "^5.12.0",
+    "mongoose": "^6.0.14",
     "mongoose-validator": "^1.3.2",
     "node-fetch": ">=2.6.1",
     "nodemailer": "^6.4.16",


### PR DESCRIPTION
# HID-2257

Some cleanup as we upgrade the MongoDB library we're using inside node.

# Testing

In general, if you see any mention of Mongo deprecations in the console, this PR needs more work.

- Login _incorrectly_ on an existing account more than five times in five minutes and make sure no deprecation warnings spring up relating to `count()`
- Use Auth to delete a user account.
- Any API call with `DELETE` verb should be tested: a user account, TOTP trusted devices, OAuth Clients, API keys, etc. 