### PR TITLE
HID-2267: clean up UserPolicy

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -59,12 +59,36 @@ module.exports = {
    *         schema:
    *           $ref: '#/components/schemas/User'
    *   '400':
-   *     description: Bad request. Missing required parameters.
+   *     description: Bad request. See response for details.
    *   '403':
    *     description: Forbidden. Your account is not allowed to create users.
    * security: []
    */
   async create(request) {
+    if (!request.payload) {
+      logger.warn(
+        '[UserController->create] No request payload provided for user creation',
+        {
+          request,
+          security: true,
+          fail: true,
+        },
+      );
+      throw Boom.badRequest('Missing request payload');
+    }
+
+    if (!request.payload.email) {
+      logger.warn(
+        '[UserController->create] No email address provided for user creation',
+        {
+          request,
+          security: true,
+          fail: true,
+        },
+      );
+      throw Boom.badRequest('Missing field: email');
+    }
+
     if (!request.payload.app_verify_url) {
       logger.warn(
         '[UserController->create] Missing app_verify_url',
@@ -74,7 +98,7 @@ module.exports = {
           fail: true,
         },
       );
-      throw Boom.badRequest('Missing app_verify_url');
+      throw Boom.badRequest('Missing field: app_verify_url');
     }
 
     const appVerifyUrl = request.payload.app_verify_url;

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -130,7 +130,11 @@ module.exports = {
       // Create user
       if (request.payload.email) {
         request.payload.emails = [];
-        request.payload.emails.push({ type: 'Work', email: request.payload.email, validated: false });
+        request.payload.emails.push({
+          type: 'Work',
+          email: request.payload.email,
+          validated: false,
+        });
       }
 
       if (request.payload.password && request.payload.confirm_password) {

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -3,28 +3,32 @@
 * @description User Policy
 */
 const Boom = require('@hapi/boom');
-const User = require('../models/User');
 const config = require('../../config/env');
 
 const { logger } = config;
 
 module.exports = {
   async canDestroy(request) {
-    if (request.auth.credentials.is_admin
-      || request.auth.credentials.id === request.params.id) {
+    // If the acting user is an admin
+    //   OR any user is targeting themselves
+    // THEN are allowed to update the target user.
+    if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
       return true;
     }
-    const user = await User.findOne({ _id: request.params.id }).populate('createdBy');
-    if (user.createdBy
-        && user.createdBy.id === request.auth.credentials.id
-        && user.email_verified === false
-        && request.auth.credentials.isManager) {
-      return true;
-    }
+
     logger.warn(
       `[UserPolicy->canDestroy] User ${request.auth.credentials.id} can not remove user ${request.params.id}`,
+      {
+        request,
+        security: true,
+        fail: true,
+        user: {
+          id: request.auth.credentials.id,
+          email: request.auth.credentials.email,
+        },
+      },
     );
-    throw Boom.unauthorized('You are not allowed to do this operation');
+    throw Boom.forbidden();
   },
 
   async canUpdate(request) {

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -8,33 +8,15 @@ const config = require('../../config/env');
 const { logger } = config;
 
 module.exports = {
-  async canDestroy(request) {
-    // If the acting user is an admin
-    //   OR any user is targeting themselves
-    // THEN are allowed to update the target user.
-    if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
-      return true;
-    }
-
-    logger.warn(
-      `[UserPolicy->canDestroy] User ${request.auth.credentials.id} can not remove user ${request.params.id}`,
-      {
-        request,
-        security: true,
-        fail: true,
-        user: {
-          id: request.auth.credentials.id,
-          email: request.auth.credentials.email,
-        },
-      },
-    );
-    throw Boom.forbidden();
-  },
-
+  /**
+   * Policy: canUpdate
+   *
+   * Any user can update themselves. Admins can update any user.
+   */
   async canUpdate(request) {
     // If the acting user is an admin
     //   OR any user is targeting themselves
-    // THEN are allowed to update the target user.
+    // THEN they are allowed to update the target user.
     if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
       return true;
     }
@@ -55,10 +37,15 @@ module.exports = {
     throw Boom.forbidden();
   },
 
+  /**
+   * Policy: canFind
+   *
+   * Any user can find themselves. Admins can find any user.
+   */
   async canFind(request) {
     // If the acting user is an admin
     //   OR any user is targeting themselves
-    // THEN are allowed to view the target user.
+    // THEN they are allowed to view the target user.
     if (request.auth.credentials.is_admin || request.auth.credentials.id === request.params.id) {
       return true;
     }

--- a/api/policies/UserPolicy.js
+++ b/api/policies/UserPolicy.js
@@ -9,34 +9,6 @@ const config = require('../../config/env');
 const { logger } = config;
 
 module.exports = {
-  canCreate(request) {
-    if (!request.auth.credentials) {
-      if (!request.payload) {
-        logger.warn(
-          '[UserPolicy->canCreate] No request payload provided for user creation',
-          { request: request.payload, fail: true },
-        );
-        throw Boom.badRequest('Missing request payload');
-      } else if (!request.payload.email) {
-        // Strip out sensitive fields before logging
-        delete request.payload.password;
-        delete request.payload.confirm_password;
-
-        logger.warn(
-          '[UserPolicy->canCreate] No email address provided for user creation',
-          { request: request.payload, fail: true },
-        );
-        throw Boom.badRequest('You need to register with an email address');
-      }
-    } else if (!request.auth.credentials.is_admin && !request.auth.credentials.isManager) {
-      logger.warn(
-        `[UserPolicy->canCreate] User ${request.auth.credentials.id} tried to create another user even though he is not an admin or manager`,
-      );
-      throw Boom.forbidden('Only administrators and managers can create users');
-    }
-    return true;
-  },
-
   async canDestroy(request) {
     if (request.auth.credentials.is_admin
       || request.auth.credentials.id === request.params.id) {

--- a/config/routes.js
+++ b/config/routes.js
@@ -347,12 +347,7 @@ module.exports = [
   {
     method: 'POST',
     path: '/api/v3/user',
-    options: {
-      pre: [
-        UserPolicy.canCreate,
-      ],
-      handler: UserController.create,
-    },
+    handler: UserController.create,
   },
 
   {

--- a/config/routes.js
+++ b/config/routes.js
@@ -398,7 +398,7 @@ module.exports = [
     path: '/api/v3/user/{id}',
     options: {
       pre: [
-        UserPolicy.canDestroy,
+        UserPolicy.canUpdate,
         AuthPolicy.isTOTPEnabledAndValid,
       ],
       handler: UserController.destroy,

--- a/config/routes.js
+++ b/config/routes.js
@@ -398,6 +398,7 @@ module.exports = [
     path: '/api/v3/user/{id}',
     options: {
       pre: [
+        UserPolicy.canDestroy,
         AuthPolicy.isTOTPEnabledAndValid,
       ],
       handler: UserController.destroy,


### PR DESCRIPTION
# HID-2267

We had a PR a while back where the point was raised that UserPolicy does content validation. This is my effort to clean it up and provide clear separation of concerns.

- `UserPolicy` does permission checks only, and returns a simpler set of response codes.
- `UserPolicy.canDestroy` was consolidated since after cleanup it had identical permission checks to `canUpdate`
- `UserController.create` now handles content validation specific to this function
- `UserController.destroy` now protected by a policy, and outputs simpler error codes.

## Testing

Regular users

- Create a new user and verify the account by clicking confirmation email.
- Confirm that it **can** view itself: `GET /api/v3/user/{id}`
- Confirm that it **can** delete itself: `DELETE /api/v3/user/{id}`

Admins

- Find an admin user
- Confirm that admin **can** view itself: `GET /api/v3/user/{id}`
- Confirm that admin **can** view other users `GET /api/v3/user/{id}`
- Confirm that admin **can** view others in bulk: `GET /api/v3/user`
- Confirm that admin **can** delete another user: `DELETE /api/v3/user/{id}`
- Confirm that admin **CANNOT** delete itself: `DELETE /api/v3/user/{id}`
