### PR TITLE
HID-2327: fix regression related to user-friendly registration errors

### DIFF
--- a/api/controllers/ViewController.js
+++ b/api/controllers/ViewController.js
@@ -311,10 +311,10 @@ module.exports = {
 
       // Check the error for a few special cases to provide better user feedback.
       // All of these will render the registration form.
-      if (errorMessage && errorMessage.indexOf('password is not strong') !== -1) {
+      if (errorMessage && errorMessage.indexOf('password does not meet') !== -1) {
         userMessage = 'Your password was not strong enough. Please check the requirements and try again.';
       }
-      if (errorMessage && errorMessage.indexOf('passwords do not match') !== -1) {
+      if (errorMessage && errorMessage.indexOf('fields do not match') !== -1) {
         userMessage = 'Your password fields did not match. Please try again and carefully confirm the password.';
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14061,7 +14061,8 @@
       "dependencies": {
         "ansi-regex": {
           "version": "5.0.0",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "emoji-regex": {
           "version": "8.0.0",


### PR DESCRIPTION
# HID-2327

No new logic, but when I implemented cracklib for user registration, I changed the errors coming out of `UserController.create()` and didn't update `ViewController.registerPost()` to scan for the new strings.

## Testing

- Create new user account (don't forget to comment out the reCAPTCHA challenge in ViewController submit handler)
- Enter a valid, but weak password, like `123456789aA!` in both fields
- The form should prevent registration and display a warning:

> Your password was not strong enough. Please check the requirements and try again.

- Open your devtools and momentarily disable JS, then refresh the page to try a second registration.
- While filling the form, enter **two different passwords**.
- The form should prevent registration and display a warning:

> Your password fields did not match. Please try again and carefully confirm the password.
