### PR TITLE
HID-2336: supply correct client_id value when generating OAuth tokens

### DIFF
--- a/api/models/OauthToken.js
+++ b/api/models/OauthToken.js
@@ -70,7 +70,7 @@ OauthTokenSchema.statics = {
       {
         oauth: {
           type,
-          client_id: client._id,
+          client_id: client.id,
         },
         user: {
           id: user._id,


### PR DESCRIPTION
# HID-2336

We were logging the DB id instead of the OAuth client ID when generating OAuth tokens. To confirm fix, log into a Drupal site with HID and scan the logs to confirm that we're outputting human-readable values for `oauth.client_id` when the various tokens get generated:

```
hid-api-1  | {"oauth":{"type":"refresh","client_id":"ocha-2022-gho-unocha-org-local"}..."message":"[OauthToken->generate] generating refresh OAuth token"...
hid-api-1  | {"oauth":{"type":"access","client_id":"ocha-2022-gho-unocha-org-local"}..."message":"[OauthToken->generate] generating access OAuth token"...
```

Fixes regression introduced in https://github.com/UN-OCHA/hid-api/commit/8c7f91d9786ae0aab59d1cc301a25a2e604b36f0#diff-782db861e1fe49c725579627e013a575c81ad7aafa7f316247c35a3ea2d25636R73