### PR TITLE
[HID-2320] prevent errors during OAuth dialog confirmations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,9 +2509,8 @@
       }
     },
     "@hapi/yar": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/yar/-/yar-10.1.1.tgz",
-      "integrity": "sha512-FUI+cnCIMAws9mhLzITo12cdnLUWSWVPmSnh1ILaROjUCm1uA88DOGIZORUfHBf/+NMI10V2d+nyV2PZtKVd7g==",
+      "version": "github:un-ocha/yar#c3ef5a541cf5c19184347c4e32f683aa060d5953",
+      "from": "github:un-ocha/yar#fix/lazy-mode",
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/statehood": "7.x.x",
@@ -2519,9 +2518,9 @@
       },
       "dependencies": {
         "@hapi/hoek": {
-          "version": "9.2.0",
-          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.0.tgz",
-          "integrity": "sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug=="
+          "version": "9.2.1",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+          "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
         },
         "uuid": {
           "version": "8.3.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@hapi/iron": "^6.0.0",
     "@hapi/scooter": "^6.0.1",
     "@hapi/vision": "^5.5.4",
-    "@hapi/yar": "^10.1.1",
+    "@hapi/yar": "github:un-ocha/yar#master",
     "accept-language": "^3.0.15",
     "async": "^2.1.2",
     "authenticator": "^1.1.2",


### PR DESCRIPTION
# HID-2320

Two investigations indicate that the 'lazy' mode of `yar` was the source of problems within our `oauth2orize` plugin, leading visitors who confirm an OAuth connection to see an error some of the time.

[We forked the library](https://github.com/UN-OCHA/yar) and are using it as our dependency while we await a resolution to the upstream PR.

