### PR TITLE
[HID-2320] reinstall to update package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2509,8 +2509,8 @@
       }
     },
     "@hapi/yar": {
-      "version": "github:un-ocha/yar#c3ef5a541cf5c19184347c4e32f683aa060d5953",
-      "from": "github:un-ocha/yar#fix/lazy-mode",
+      "version": "github:un-ocha/yar#d974f5e57883264035c2d6f4f1470fde623fa07a",
+      "from": "github:un-ocha/yar#master",
       "requires": {
         "@hapi/hoek": "9.x.x",
         "@hapi/statehood": "7.x.x",


### PR DESCRIPTION
# HID-2320

Switches to master branch of our `@hapi/yar` fork. Previously we were pointing at our internal PR branch, and I _think_ the package-lock.json will favor the commit hash it has listed over the specific branch name, but I'm cleaning this up to be extra certain.
