### PR TITLE
[HID-2342] ensure future releases skip creation of git tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file. See [standa
 ### Bug Fixes
 
 * security: updates to dependencies
-
 * prevent errors during OAuth dialog confirmations ([c98b59f](https://github.com/UN-OCHA/hid-api/commit/c98b59fdf0ecebb89a233c967b0c900974108c1f))
 
 ## [5.1.2](https://github.com/UN-OCHA/hid-api/compare/v5.1.1...v5.1.2) (2022-02-04)

--- a/package.json
+++ b/package.json
@@ -87,5 +87,11 @@
   "engines": {
     "node": "14.15.4",
     "npm": "6.14.10"
+  },
+  "//": "To integrate with our release process, we instruct standard-version to skip creation of git tags, which we manage on GitHub.",
+  "standard-version": {
+    "skip": {
+      "tag": true
+    }
   }
 }


### PR DESCRIPTION
# HID-2342

Since we manage the tags via GitHub Releases, we don't want our command-line tool to make tags for us. Nice find from @lazysoundsystem 