### PR TITLE
[OPS-7830] Turns out the docker env is passed as a string boolean with a capital T, so check for that.

### DIFF
--- a/config/web.js
+++ b/config/web.js
@@ -72,7 +72,7 @@ module.exports = {
             host: process.env.REDIS_HOST || 'redis',
             port: process.env.REDIS_PORT || 6379,
             db: process.env.REDIS_DB || '0',
-            tls: process.env.REDIS_TLS === 'true' ? {} : null,
+            tls: process.env.REDIS_TLS === 'True' ? {} : null,
           },
         },
       },


### PR DESCRIPTION
Turns out `{}` works fine as a TLS config object with the AWS certificate and chain, as evidenced by the `dev` site right now. It may not work so well with self-signed certs. 

Also, it does not work at all with the conditional I added. When set to `null`, the tls config will cause the API to just outright throw 502 Nope. So it will need work, possibly a conditional cache config export based on the redis TLS env variable. Yay, wheee!