### PR TITLE
build: Submodules are a bad idea and make many people very angry.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        submodules: true
 
     - name: Build
       id: build-action


### PR DESCRIPTION
So we turn them off, which will fail the build if someone tries to sneak one in. Win-win!