### PR TITLE
[HID-2361] correct paths for alert include within settings pages

### DIFF
--- a/templates/settings-delete.html
+++ b/templates/settings-delete.html
@@ -28,7 +28,7 @@
 
           <% if (user.is_admin) { %>
               <%-
-                include('alert.html', {
+                include('includes/alert', {
                   alert: {
                     type: 'warning',
                     title: 'Admins cannot delete their own account',

--- a/templates/settings-security.html
+++ b/templates/settings-security.html
@@ -51,7 +51,7 @@
             %>
               <div class="step-2">
                 <%-
-                  include('alert.html', {
+                  include('includes/alert', {
                     alert: {
                       type: 'status',
                       message: '<p>Your two-factor authentication is <strong>Enabled</strong>. However, keep reading for the final step.</p>',
@@ -59,7 +59,7 @@
                   })
                 %>
                 <%-
-                  include('alert.html', {
+                  include('includes/alert', {
                     alert: {
                       type: 'warning',
                       message: `
@@ -92,7 +92,7 @@
               <div class="step-1">
                 <% if (formData && formData.totpConf) { %>
                   <%-
-                    include('alert.html', {
+                    include('includes/alert', {
                       alert: {
                         type: 'info',
                         message: `
@@ -121,7 +121,7 @@
                 <% } else { %>
 
                   <%-
-                    include('alert.html', {
+                    include('includes/alert', {
                       alert: {
                         type: 'warning',
                         message: '<p>There was a problem displaying your two-factor authentication setup data. If this problem persists please email info@humanitarian.id and include this error code: SEC-1-QR.</p>',


### PR DESCRIPTION
# HID-2361

Fixes the include paths for a few settings pages. The "delete account" page is for admins only, so very low impact on prod. The other page does indeed prevent 2FA from being enabled on all environments.

@lazysoundsystem you can go ahead and give this a YOLO and we'll test it on dev, where the problem is currently reproducible. 