### PR TITLE
chore: bump public-facing API version indicator

### DIFF
--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 5.1.1
+  version: 5.1.8
   title: HID API
   license:
     name: Apache-2.0


### PR DESCRIPTION
We won't know the next version until we cut a release but at least it matches the latest version that exists.

Refs: HID-2362