### PR TITLE
[HID-2372] new endpoint to force-reset user passwords

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -822,7 +822,7 @@ module.exports = {
     });
 
     logger.info(
-      `[UserController->updatePassword] Admin forced a password reset`,
+      '[UserController->updatePassword] Admin forced a password reset',
       {
         request,
         security: true,

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -707,7 +707,6 @@ module.exports = {
 
     // Does the new password match any historical hashes?
     if (user.isHistoricalPassword(newPassword)) {
-      // Business logic: is the new password different than the old one?
       logger.warn(
         `[UserController->updatePassword] Could not update user password for user ${userId}. New password is the same as old password.`,
         {
@@ -746,6 +745,10 @@ module.exports = {
       {
         request,
         security: true,
+        user: {
+          id: user.id,
+          email: user.email,
+        },
       },
     );
 
@@ -1676,7 +1679,7 @@ module.exports = {
     return reply.response().code(204);
   },
 
-  /*
+  /**
    * @api [delete] /user/{id}/clients/{client}
    * tags:
    *   - user

--- a/api/models/User.js
+++ b/api/models/User.js
@@ -499,7 +499,7 @@ UserSchema.statics = {
   // Generate a cryptographically strong random password.
   generateRandomPassword() {
     const buffer = crypto.randomBytes(256);
-    return `${buffer.toString('hex').slice(0, 10)}B`;
+    return `${buffer.toString('hex').slice(0, 24)}B`;
   },
 };
 

--- a/api/policies/AuthPolicy.js
+++ b/api/policies/AuthPolicy.js
@@ -110,10 +110,17 @@ module.exports = {
     return true;
   },
 
+  /**
+   * Policy for mandatory TOTP challenges.
+   */
   async isTOTPValidPolicy(request) {
     const user = request.auth.credentials;
     const token = request.headers['x-hid-totp'];
+
+    // Validate the TOTP code.
     await isTOTPValid(user, token);
+
+    // If no error was thrown, return true.
     return true;
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -445,6 +445,22 @@ module.exports = [
 
   {
     method: 'POST',
+    path: '/api/v3/user/{id}/password-admin',
+    options: {
+      pre: [
+        AuthPolicy.isAdmin,
+      ],
+      handler: UserController.adminForceUpdatePassword,
+      validate: {
+        params: Joi.object({
+          id: Joi.string().regex(objectIdRegex),
+        }),
+      },
+    },
+  },
+
+  {
+    method: 'POST',
     path: '/api/v3/user/{id}/emails',
     options: {
       pre: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -12450,7 +12450,7 @@
     "sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
       "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"


### PR DESCRIPTION
# HID-2372

Endpoint force-resets a user's password to something random. The admin never has access to the account, and it can't ever see the password either.

Afterwards, the target user must perform a successful password reset via email link in order to regain access to the account.

## Testing

1. Generate new docs by running `npm run docs` inside container.
2. Generate a JWT for an admin within your local DB.
3. `POST /api/v3/user/{id}/password-admin` via [local swagger](http://hid.test:8080/docs/#/user/post_user__id__password_admin)

Additional confirmation can be observed by logging into HID successfully beforehand with the target user, then confirming that the same password no longer works after the reset (UI won't say why, but logs will specifically confirm wrong password).