### PR TITLE
chore(release): 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.2.1](https://github.com/UN-OCHA/hid-api/compare/v5.2.0...v5.2.1) (2023-02-09)
+
+### Bug Fixes
+
+* regular security updates
+
+### Chores
+
+* **ci**: migrate from Travis to GHA
+
+
 ## [5.2.0](https://github.com/UN-OCHA/hid-api/compare/v5.1.9...v5.2.0) (2023-01-12)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid-api.git",


### PR DESCRIPTION
## [5.2.1](https://github.com/UN-OCHA/hid-api/compare/v5.2.0...v5.2.1) (2023-02-09)

### Bug Fixes

* regular security updates

### Chores

* **ci**: migrate from Travis to GHA
