### PR TITLE
chore(release): 5.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.2.4](https://github.com/UN-OCHA/hid-api/compare/v5.2.3...v5.2.4) (2023-05-04)
+
+### Chores
+
+* regular security updates
+
+
 ## [5.2.3](https://github.com/UN-OCHA/hid-api/compare/v5.2.2...v5.2.3) (2023-04-06)
 
 ### Chores

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 5.2.3
+  version: 5.2.4
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hid-api",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hid-api",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid-api.git",


### PR DESCRIPTION
## [5.2.4](https://github.com/UN-OCHA/hid-api/compare/v5.2.3...v5.2.4) (2023-05-04)

### Chores

* **security**: regular security updates
