### PR TITLE
[HID-2387] user counts

### DIFF
--- a/api/controllers/NumbersController.js
+++ b/api/controllers/NumbersController.js
@@ -1,0 +1,65 @@
+/**
+ * @module NumbersController
+ * @description Provides aggregate counts for: users.
+ */
+const Boom = require('@hapi/boom');
+const User = require('../models/User');
+const config = require('../../config/env');
+
+const { logger } = config;
+
+module.exports = {
+
+  /*
+   * @api [get] /numbers
+   * tags:
+   *   - numbers
+   * summary: Returns total number of users in the database.
+   * responses:
+   *   '200':
+   *     description: Object
+   *     content:
+   *       application/json:
+   *         schema:
+   *           type: object
+   *           properties:
+   *             totalUsers:
+   *               type: integer
+   *               required: true
+   *             emailVerified:
+   *               type: integer
+   *               required: true
+   *   '400':
+   *     description: Bad request. See response body for details.
+   *   '401':
+   *     description: Unauthorized. Invalid token.
+   *   '403':
+   *     description: Unauthorized. You are not an admin.
+   */
+  async numbers(request) {
+    try {
+      const [
+        totalUsers,
+        emailVerified,
+      ] = await Promise.all([
+        User.countDocuments({}),
+        User.countDocuments({ email_verified: true }),
+      ]);
+
+      return {
+        totalUsers: totalUsers,
+        emailVerified: emailVerified,
+      };
+    } catch (err) {
+      logger.error(
+        `[NumbersController->numbers] ${err.message}`,
+        {
+          request,
+          fail: true,
+        },
+      );
+
+      throw Boom.badImplementation(err);
+    }
+  },
+};

--- a/api/controllers/NumbersController.js
+++ b/api/controllers/NumbersController.js
@@ -47,8 +47,8 @@ module.exports = {
       ]);
 
       return {
-        totalUsers: totalUsers,
-        emailVerified: emailVerified,
+        totalUsers,
+        emailVerified,
       };
     } catch (err) {
       logger.error(

--- a/config/routes.js
+++ b/config/routes.js
@@ -278,6 +278,9 @@ module.exports = [
     },
   },
 
+  /**
+   * HID Login
+   */
   {
     method: 'POST',
     path: '/login',
@@ -287,6 +290,9 @@ module.exports = [
     },
   },
 
+  /**
+   * OAuth
+   */
   {
     method: 'GET',
     path: '/oauth/authorize',
@@ -325,6 +331,9 @@ module.exports = [
     },
   },
 
+  /**
+   * API Key management
+   */
   {
     method: 'POST',
     path: '/api/v3/jsonwebtoken',
@@ -343,6 +352,9 @@ module.exports = [
     handler: AuthController.blacklistJwt,
   },
 
+  /**
+   * User management
+   */
   {
     method: 'POST',
     path: '/api/v3/user',
@@ -525,6 +537,9 @@ module.exports = [
     },
   },
 
+  /**
+   * OAuth Client management
+   */
   {
     method: 'DELETE',
     path: '/api/v3/user/{id}/clients/{client}',
@@ -601,6 +616,9 @@ module.exports = [
     },
   },
 
+  /**
+   * TOTP management
+   */
   {
     method: 'POST',
     path: '/api/v3/totp/config',

--- a/config/routes.js
+++ b/config/routes.js
@@ -13,6 +13,7 @@ const AdminController = require('../api/controllers/AdminController');
 const AuthController = require('../api/controllers/AuthController');
 const AuthPolicy = require('../api/policies/AuthPolicy');
 const ClientController = require('../api/controllers/ClientController');
+const NumbersController = require('../api/controllers/NumbersController');
 const TOTPController = require('../api/controllers/TOTPController');
 const UserController = require('../api/controllers/UserController');
 const UserPolicy = require('../api/policies/UserPolicy');
@@ -685,6 +686,20 @@ module.exports = [
         AuthPolicy.isTOTPValidPolicy,
       ],
       handler: TOTPController.verifyTOTPToken,
+    },
+  },
+
+  /**
+   * Numbers
+   */
+  {
+    method: 'GET',
+    path: '/api/v3/numbers',
+    options: {
+      pre: [
+        AuthPolicy.isAdmin,
+      ],
+      handler: NumbersController.numbers,
     },
   },
 ];


### PR DESCRIPTION
# HID-2387

Admin-only endpoint for aggregate user counts.

### Testing

- `GET /api/v3/numbers`
- No token or non-admin token should 403
- Bad token should 401
- Admin token should 200 with a JSON object:

```json
{
  "totalUsers": 321,
  "emailVerified": 123,
}
```