### PR TITLE
fix: explicitly set DB option to suppress deprecation warning

### DIFF
--- a/server.js
+++ b/server.js
@@ -121,6 +121,7 @@ exports.init = async () => {
 // Define server start
 exports.start = async () => {
   // Connect to DB
+  mongoose.set('strictQuery', false);
   mongoose.connect(store.uri, store.options);
 
   await server.start();


### PR DESCRIPTION
The value we set is the current default for Mongoose 6, but the default will change to false in Mongoose 7. Therefore the warning was popping up.

The more conservative option is false, meaning invalid query parameters do NOT result in entire collections getting returned.

Refs: HID-2395