### PR TITLE
chore(release): 5.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
-### [5.3.2](https://github.com/UN-OCHA/hid-api/compare/v5.3.1...v5.3.2) (2023-10-17)
+
+## [5.3.3](https://github.com/UN-OCHA/hid-api/compare/v5.3.2...v5.3.3) (2023-10-19)
+
+### Bug Fixes
+
+* explicitly set DB option to suppress deprecation warning ([23afd27](https://github.com/UN-OCHA/hid-api/commit/23afd27241662f47051f8399683259e3368c8b11))
+
+## [5.3.2](https://github.com/UN-OCHA/hid-api/compare/v5.3.1...v5.3.2) (2023-10-17)
 
 - Security updates
 
-### [5.3.1](https://github.com/UN-OCHA/hid-api/compare/v5.3.0...v5.3.1) (2023-08-28)
 
+## [5.3.1](https://github.com/UN-OCHA/hid-api/compare/v5.3.0...v5.3.1) (2023-08-28)
 
 ### Bug Fixes
 
 * Sigh. ([3bd603f](https://github.com/UN-OCHA/hid-api/commit/3bd603f216ae5282ac4756ef473d5f090e4a00fa))
 * Use slack channel from vars, so dependabot can see it. ([46cfef0](https://github.com/UN-OCHA/hid-api/commit/46cfef0490a600ca2046862fc11e8dfaa69af070))
+
 
 ## [5.3.0](https://github.com/UN-OCHA/hid-api/compare/v5.2.4...v5.3.0) (2023-06-01)
 

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 5.3.2
+  version: 5.3.3
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hid-api",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hid-api",
-      "version": "5.3.2",
+      "version": "5.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid-api.git",


### PR DESCRIPTION
## [5.3.3](https://github.com/UN-OCHA/hid-api/compare/v5.3.2...v5.3.3) (2023-10-19)

### Bug Fixes

* explicitly set DB option to suppress deprecation warning ([23afd27](https://github.com/UN-OCHA/hid-api/commit/23afd27241662f47051f8399683259e3368c8b11))
