### PR TITLE
chore(release): 5.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.3.7](https://github.com/UN-OCHA/hid-api/compare/v5.3.6...v5.3.7) (2024-05-02)
+
+### Bug Fixes
+
+* **a11y:** replace redundant role with aria-label on main tags ([297acc7](https://github.com/UN-OCHA/hid-api/commit/297acc7f806b61613b7699c97159268487f8f683))
+* **a11y:** update landmark roles with labels ([4a492d1](https://github.com/UN-OCHA/hid-api/commit/4a492d1374e4a96e6827e001141ee9056487f85e))
+* **security:** new GTM hash for CSP ([aeb1e07](https://github.com/UN-OCHA/hid-api/commit/aeb1e07d027a040f96412260b5d29f7f0aabb984))
+* **CD:** compile CSS ([b1961ac](https://github.com/UN-OCHA/hid-api/commit/b1961ac204c673695680ac459c2db0c03c722b0d))
+* **CD:** update CD Alert markup ([ba43e82](https://github.com/UN-OCHA/hid-api/commit/ba43e82872e36ab4809ddad790f5b245454413c9))
+* **CD:** update OCHA logos ([acb00c3](https://github.com/UN-OCHA/hid-api/commit/acb00c39e3a742569e49279b29272a241d7467d7))
+* **CD:** update OCHA Services to be in footer ([4470492](https://github.com/UN-OCHA/hid-api/commit/4470492ad260d617886f65a11fee95cd2326168e))
+* **CD:** update SVG sprite ([ba6bf38](https://github.com/UN-OCHA/hid-api/commit/ba6bf388631020d02fd1b6b2d104530929b70d6f))
+* **CD:** update copyright ([0424d34](https://github.com/UN-OCHA/hid-api/commit/0424d348d78fe455841bd5e17578c09e6b949c47))
+* **CD:** update JS for HID ([eac1738](https://github.com/UN-OCHA/hid-api/commit/eac17382e78e76e9ad9dfa3bb183302e828dd4b8))
+
 ### [5.3.6](https://github.com/UN-OCHA/hid-api/compare/v5.3.5...v5.3.6) (2024-04-04)
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,6 +302,10 @@ Once the tagged Release has been created, [create a PR from `dev` to `main`][pr-
 
 ## CD Upgrades
 
+| Audience    |
+| :---------- |
+| Maintainers |
+
 Since HID doesn't use Drupal, a few manual tasks are required to update certain files during CD upgrades.
 
 

--- a/docs/swaggerBase.yaml
+++ b/docs/swaggerBase.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 x-api-id: hid-api
 info:
-  version: 5.3.6
+  version: 5.3.7
   title: HID API
   license:
     name: Apache-2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hid-api",
-  "version": "5.3.6",
+  "version": "5.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hid-api",
-      "version": "5.3.6",
+      "version": "5.3.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hid-api",
-  "version": "5.3.6",
+  "version": "5.3.7",
   "description": "Humanitarian ID API+Auth",
   "homepage": "https://about.humanitarian.id",
   "repository": "https://github.com/UN-OCHA/hid-api.git",


### PR DESCRIPTION
### [5.3.7](https://github.com/UN-OCHA/hid-api/compare/v5.3.6...v5.3.7) (2024-05-02)

### Bug Fixes

* **a11y:** replace redundant role with aria-label on main tags ([297acc7](https://github.com/UN-OCHA/hid-api/commit/297acc7f806b61613b7699c97159268487f8f683))
* **a11y:** update landmark roles with labels ([4a492d1](https://github.com/UN-OCHA/hid-api/commit/4a492d1374e4a96e6827e001141ee9056487f85e))
* **security:** new GTM hash for CSP ([aeb1e07](https://github.com/UN-OCHA/hid-api/commit/aeb1e07d027a040f96412260b5d29f7f0aabb984))
* **CD:** compile CSS ([b1961ac](https://github.com/UN-OCHA/hid-api/commit/b1961ac204c673695680ac459c2db0c03c722b0d))
* **CD:** update CD Alert markup ([ba43e82](https://github.com/UN-OCHA/hid-api/commit/ba43e82872e36ab4809ddad790f5b245454413c9))
* **CD:** update OCHA logos ([acb00c3](https://github.com/UN-OCHA/hid-api/commit/acb00c39e3a742569e49279b29272a241d7467d7))
* **CD:** update OCHA Services to be in footer ([4470492](https://github.com/UN-OCHA/hid-api/commit/4470492ad260d617886f65a11fee95cd2326168e))
* **CD:** update SVG sprite ([ba6bf38](https://github.com/UN-OCHA/hid-api/commit/ba6bf388631020d02fd1b6b2d104530929b70d6f))
* **CD:** update copyright ([0424d34](https://github.com/UN-OCHA/hid-api/commit/0424d348d78fe455841bd5e17578c09e6b949c47))
* **CD:** update JS for HID ([eac1738](https://github.com/UN-OCHA/hid-api/commit/eac17382e78e76e9ad9dfa3bb183302e828dd4b8))