### PR TITLE
chore: Reduce valkey storage use by reducing the cookie ttl.

### DIFF
--- a/config/web.js
+++ b/config/web.js
@@ -104,8 +104,8 @@ const config = {
           // Adopt our server-side cache defined in top-level `options`.
           cache: 'session',
 
-          // 1-week sessions
-          expiresIn: 7 * 24 * 60 * 60 * 1000,
+          // 1-day sessions
+          expiresIn: 24 * 60 * 60 * 1000,
         },
 
         // Force use of backend storage.


### PR DESCRIPTION
The production valkey is shared. It is anyway more secure to not let logins remain active for a week. A day means someone remains logged in over night, but if they are away for the weekend they need to enter credentials again. That seems not unreasonable. Also, sites should not be using HID any more, so it may as well get slightly less convenient.

And it saves us on valkey usage alerts :-)

Refs: HID-2434